### PR TITLE
Fix typo in pitch linearization comment

### DIFF
--- a/Week 2/pitch_linearization_m.m
+++ b/Week 2/pitch_linearization_m.m
@@ -15,7 +15,7 @@
 % * Inputs: elevator deflection $\delta_e$
 % * States: $x = [\theta; q]$
 %% 
-% Try to linearize the system model to a state-space representaion. 
+% Try to linearize the system model to a state-space representation.
 %% Method 1: Analynical solution
 
 % Step 1: Define Symbolic Nonlinear Model


### PR DESCRIPTION
## Summary
- correct typo in Week 2 pitch linearization script

## Testing
- `octave -qf 'Week 2/pitch_linearization_m.m'` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad38a49924832bac9b8ecc425b3575