### PR TITLE
Comment section headers in second_oder_system.m

### DIFF
--- a/Week 1/second_oder_system.m
+++ b/Week 1/second_oder_system.m
@@ -1,5 +1,5 @@
-Second-Order System – Spring-Mass-Damper Response
-Underdamped Systems
+% Second-Order System – Spring-Mass-Damper Response
+% Underdamped Systems
 % System parameters
 m = 1;      % mass (kg)
 c = 2;      % damping (Ns/m)
@@ -25,7 +25,7 @@ ylabel('Displacement (m)');
 % Show damping and natural frequency
 damp(sys)
 
-Undamped Systems
+% Undamped Systems
 % System parameters
 m = 1;      % mass (kg)
 c = 0;      % damping (Ns/m)
@@ -51,7 +51,7 @@ ylabel('Displacement (m)');
 % Show damping and natural frequency
 damp(sys)
 
-Overdamped Systems
+% Overdamped Systems
 % System parameters
 m = 1;      % mass (kg)
 c = 6;      % damping (Ns/m)
@@ -76,7 +76,7 @@ ylabel('Displacement (m)');
 
 % Show damping and natural frequency
 damp(sys)
-Critically-Damped Systems
+% Critically-Damped Systems
 % System parameters
 m = 1;      % mass (kg)
 c = 4;      % damping (Ns/m)


### PR DESCRIPTION
## Summary
- comment second-order system header and section labels so MATLAB treats them as comments

## Testing
- `matlab -batch "run('Week 1/second_oder_system.m')"` *(fails: command not found)*
- `sudo apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad38e460d4832bbf738104106c1204