### PR TITLE
Fix typo in pitch rate comment

### DIFF
--- a/Week 3/Q2.m
+++ b/Week 3/Q2.m
@@ -9,7 +9,7 @@ B = [2.38    0.0;
      0.0    -0.8435;
      0.0     0.0];
 
-% Output: pitch rate (q), which is the 3nd state
+% Output: pitch rate (q), which is the 3rd state.
 C = [0 0 1 0];
 D = [0 0];
 


### PR DESCRIPTION
## Summary
- Correct pitch rate comment to refer to the third state in Week 3/Q2.m

## Testing
- `octave --version` *(fails: command not found)*
- `matlab -batch "run('Week 3/Q2.m')"` *(fails: command not found)*
- `apt-get update` *(fails: 403 Repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad38fee7e0832bbb7e7a0ec69da474